### PR TITLE
fix: current node will auto delete the unregister member, so there sh…

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -107,6 +107,9 @@ func (c *cluster) Unregister(_ context.Context, req *clusterpb.UnregisterRequest
 	// Notify registered node to update remote services
 	delMember := &clusterpb.DelMemberRequest{ServiceAddr: req.ServiceAddr}
 	for _, m := range c.members {
+		if m.MemberInfo().ServiceAddr == c.currentNode.ServiceAddr {
+			continue
+		}
 		pool, err := c.rpcClient.getConnPool(m.memberInfo.ServiceAddr)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
fix: current node will auto delete the unregister member, so there should not using rpc call current node to delete the member, or it will cause panic


### What is changed and how it works?
changed the cluster unregister rpc method. 
because current node will auto delete the member, so if range members and using rpc call them 
will cause panic: 
```
     

	// Notify registered node to update remote services
	delMember := &clusterpb.DelMemberRequest{ServiceAddr: req.ServiceAddr}
	for _, m := range c.members {
		pool, err := c.rpcClient.getConnPool(m.memberInfo.ServiceAddr)
		if err != nil {
			return nil, err
		}
		client := clusterpb.NewMemberClient(pool.Get())

                   // we have find index . and if index == len(c.members), this action will 
                  // delete the members cause len(c.members) --
		_, err = client.DelMember(context.Background(), delMember)
		if err != nil {
			return nil, err
		}
	}

	log.Println("Exists peer unregister to cluster", req.ServiceAddr)

	// Register services to current node
	c.currentNode.handler.delMember(req.ServiceAddr)
	c.mu.Lock()
	if index == len(c.members)-1 {
		c.members = c.members[:index]
	} else {
                // and this action will cause panic. 
		c.members = append(c.members[:index], c.members[index+1:]...)
	}
	c.mu.Unlock()

```

Tests <!-- At least one of them must be included. -->
 - No code

Related changes

 - Need to be included in the release note


This is the action to repetition the case: 

```
cd examples/cluster
go build

# run master server
./cluster master
./cluster gate --listen "127.0.0.1:34570" --gate-address "127.0.0.1:34590"
./cluster chat --listen "127.0.0.1:34580"
```

1. stop chat. then master panic down. 

stack: 
```
2019/12/20 11:40:50 main.go:94: Nano master server web content directory /Users/mrj/Desktop/golibs/nano/examples/cluster/master/web
2019/12/20 11:40:50 main.go:95: Nano master listen address 127.0.0.1:34567
2019/12/20 11:40:50 main.go:96: Open http://127.0.0.1:12345/web/ in browser
2019/12/20 11:40:50 handler.go:114: Register local handler TopicService.Stats
2019/12/20 11:40:50 handler.go:114: Register local handler TopicService.NewUser
2019/12/20 11:40:50 interface.go:106: Startup *Nano backend server* ___master, service address 127.0.0.1:34567
2019/12/20 11:40:58 cluster.go:79: New peer register to cluster 127.0.0.1:34570
2019/12/20 11:40:58 handler.go:131: Register remote service BindService
2019/12/20 11:41:06 cluster.go:79: New peer register to cluster 127.0.0.1:34580
2019/12/20 11:41:06 handler.go:131: Register remote service RoomService
2019/12/20 11:41:09 cluster.go:124: Exists peer unregister to cluster 127.0.0.1:34580
panic: runtime error: slice bounds out of range [3:2]

goroutine 203 [running]:
github.com/lonng/nano/cluster.(*cluster).Unregister(0xc0000ce780, 0x1688120, 0xc000314480, 0xc00009d1d0, 0xc0000ce780, 0xc000314480, 0xc000201a58)
        /Users/mrj/Desktop/golibs/nano/cluster/cluster.go:132 +0x6b0
github.com/lonng/nano/cluster/clusterpb._Master_Unregister_Handler(0x156d380, 0xc0000ce780, 0x1688120, 0xc000314480, 0xc00014c320, 0x0, 0x1688120, 0xc000314480, 0xc00017c180, 0x11)
        /Users/mrj/Desktop/golibs/nano/cluster/clusterpb/cluster.pb.go:493 +0x217
google.golang.org/grpc.(*Server).processUnaryRPC(0xc000086a80, 0x168d380, 0xc000087c80, 0xc0001fe000, 0xc00012a6c0, 0x19fa738, 0x0, 0x0, 0x0)
        /Users/mrj/Desktop/target-gopath/pkg/mod/google.golang.org/grpc@v1.20.1/server.go:972 +0x46a
google.golang.org/grpc.(*Server).handleStream(0xc000086a80, 0x168d380, 0xc000087c80, 0xc0001fe000, 0x0)
        /Users/mrj/Desktop/target-gopath/pkg/mod/google.golang.org/grpc@v1.20.1/server.go:1252 +0xd97
google.golang.org/grpc.(*Server).serveStreams.func1.1(0xc0005f4030, 0xc000086a80, 0x168d380, 0xc000087c80, 0xc0001fe000)
        /Users/mrj/Desktop/target-gopath/pkg/mod/google.golang.org/grpc@v1.20.1/server.go:691 +0xbb
created by google.golang.org/grpc.(*Server).serveStreams.func1
        /Users/mrj/Desktop/target-gopath/pkg/mod/google.golang.org/grpc@v1.20.1/server.go:689 +0xa1


```

















