### PR TITLE
add a customer filter to find session

### DIFF
--- a/group.go
+++ b/group.go
@@ -58,6 +58,20 @@ func NewGroup(n string) *Group {
 	}
 }
 
+// FindMember Find a member with customer filter
+func (c *Group) FindMember(filter func(ses *session.Session) bool) (*session.Session, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	for _, s := range c.sessions {
+		if filter(s) {
+			return s, nil
+		}
+	}
+
+	return nil, ErrMemberNotFound
+}
+
 // Member returns specified UID's session
 func (c *Group) Member(uid int64) (*session.Session, error) {
 	c.mu.RLock()


### PR DESCRIPTION
在组队游戏房间的逻辑里面，有时候需要向特定的玩家逻辑服务器发送消息，提供通过自定义方法来获取session，发rpc就方便一点。