### PR TITLE
Make agent.session available to HandshakeValidator

### DIFF
--- a/cluster/handler.go
+++ b/cluster/handler.go
@@ -279,7 +279,7 @@ func (h *LocalHandler) handle(conn net.Conn) {
 func (h *LocalHandler) processPacket(agent *agent, p *packet.Packet) error {
 	switch p.Type {
 	case packet.Handshake:
-		if err := env.HandshakeValidator(p.Data); err != nil {
+		if err := env.HandshakeValidator(agent.session, p.Data); err != nil {
 			return err
 		}
 

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/lonng/nano/serialize"
 	"github.com/lonng/nano/serialize/protobuf"
+	"github.com/lonng/nano/session"
 	"google.golang.org/grpc"
 )
 
@@ -38,7 +39,7 @@ var (
 	CheckOrigin        func(*http.Request) bool // check origin when websocket enabled
 	Debug              bool                     // enable Debug
 	WSPath             string                   // WebSocket path(eg: ws://127.0.0.1/WSPath)
-	HandshakeValidator func([]byte) error       // When you need to verify the custom data of the handshake request
+	HandshakeValidator func(*session.Session, []byte) error       // When you need to verify the custom data of the handshake request
 
 	// timerPrecision indicates the precision of timer, default is time.Second
 	TimerPrecision = time.Second
@@ -57,6 +58,6 @@ func init() {
 	Heartbeat = 30 * time.Second
 	Debug = false
 	CheckOrigin = func(_ *http.Request) bool { return true }
-	HandshakeValidator = func(_ []byte) error { return nil }
+	HandshakeValidator = func(_ *session.Session, _ []byte) error { return nil }
 	Serializer = protobuf.NewSerializer()
 }

--- a/options.go
+++ b/options.go
@@ -12,6 +12,7 @@ import (
 	"github.com/lonng/nano/pipeline"
 	"github.com/lonng/nano/serialize"
 	"github.com/lonng/nano/service"
+	"github.com/lonng/nano/session"
 	"google.golang.org/grpc"
 )
 
@@ -155,7 +156,7 @@ func WithLogger(l log.Logger) Option {
 }
 
 // WithHandshakeValidator sets the function that Verify `handshake` data
-func WithHandshakeValidator(fn func([]byte) error) Option {
+func WithHandshakeValidator(fn func(*session.Session, []byte) error) Option {
 	return func(opt *cluster.Options) {
 		env.HandshakeValidator = fn
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to Nano! Please read the [CONTRIBUTING](https://github.com/lonng/nano/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Useful in some cases to be able to have access to session object at handshake validation stage (for example validate token, and store extracted user data with session)

### What is changed and how it works?
make agent.session available to HanshakeValidator func
